### PR TITLE
Expose the sidebar. The SQL dialog needs it.

### DIFF
--- a/src/main/webapp/js/mxgraph/EditorUi.js
+++ b/src/main/webapp/js/mxgraph/EditorUi.js
@@ -3295,7 +3295,9 @@ EditorUi.prototype.createToolbar = function(container)
  */
 EditorUi.prototype.createSidebar = function(container)
 {
-	return new Sidebar(this, container);
+	var sb = new Sidebar(this, container);
+	window.sb = sb;
+	return sb;
 };
 
 /**


### PR DESCRIPTION
I don't know how this worked to begin with, but something that was removed made it so that "sb" was no longer global. Now we add it to the window so the SQL dialog doesn't freak out.