### PR TITLE
Treat everything as cors to avoid a proxy

### DIFF
--- a/src/main/webapp/js/diagramly/Editor.js
+++ b/src/main/webapp/js/diagramly/Editor.js
@@ -1123,19 +1123,7 @@
 	 */
 	Editor.prototype.isCorsEnabledForUrl = function(url)
 	{
-		if (urlParams['cors'] != null && this.corsRegExp == null)
-		{
-			this.corsRegExp = new RegExp(decodeURIComponent(urlParams['cors']));
-		}
-		
-		return (this.corsRegExp != null && this.corsRegExp.test(url)) ||
-			url.substring(0, 34) === 'https://raw.githubusercontent.com/' ||
-			url.substring(0, 23) === 'https://cdn.rawgit.com/' ||
-			url.substring(0, 19) === 'https://rawgit.com/' ||
-			/^https?:\/\/[^\/]*\.blob.core.windows.net\//.test(url) ||
-			/^https?:\/\/[^\/]*\.iconfinder.com\//.test(url) ||
-			/^https?:\/\/[^\/]*\.draw\.io\/proxy/.test(url) ||
-			/^https?:\/\/[^\/]*\.github\.io\//.test(url);
+		return true;
 	};
 
 	//TODO This function is a replica of EditorUi one, it is planned to replace all calls to EditorUi one to point to this one


### PR DESCRIPTION
Removed checks that would point URLs to a non-existent proxy. Instead we will always try to get images directly from their source. Note that some images will still fail to load because they were served with no CORS headers.
